### PR TITLE
Allow stopping demo recording with ESC

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@
 Lancez le script `import_cv2.py` et choisissez l'option **D** pour "Demo".
 Vous pouvez spécifier le nombre d'étapes à capturer. Les actions réalisées
 au clavier et à la souris ainsi que les récompenses seront sauvegardées dans
-`demo_data.npy`.
+`demo_data.npy`. Appuyez sur la touche `Esc` pour interrompre l'enregistrement
+avant la fin.
 
 Ensuite relancez le script en mode **N** (nouvel apprentissage) ou **C** pour
 continuer un entraînement. Si un fichier `demo_data.npy` est présent, il sera

--- a/import_cv2.py
+++ b/import_cv2.py
@@ -298,6 +298,9 @@ class DemoRecorder:
         prev_frame = self.env.preprocess_frame(self.env.get_screen())
         prev_mouse = win32api.GetCursorPos()
         for _ in range(steps):
+            if keyboard.is_pressed('esc'):
+                print("Enregistrement arrêté par l'utilisateur.")
+                break
             act = self.env.get_player_action(prev_mouse)
             time.sleep(0.05)
             curr_frame_raw = self.env.get_screen()


### PR DESCRIPTION
## Summary
- allow stopping DemoRecorder with ESC
- document ESC usage in README

## Testing
- `python -m py_compile import_cv2.py`